### PR TITLE
remove operator repo and post only on mon

### DIFF
--- a/.github/workflows/backstage.yml
+++ b/.github/workflows/backstage.yml
@@ -3,7 +3,7 @@ name: Backstage Daily JIRA Status
 on:
   # Trigger on a cron schedule (every weekday at 4:00 PM IST)
   schedule:
-    - cron: '30 10 * * 1-5'   # Adjusted for 4:00 PM IST in UTC
+    - cron: '30 10 * * MON'   # Adjusted for 4:00 PM IST in UTC
   workflow_dispatch:  # Allow manual triggering of the workflow
 
 jobs:

--- a/backstage/team-backstage.sh
+++ b/backstage/team-backstage.sh
@@ -10,7 +10,6 @@ echo "Fetching Github datas"
 
 url1="https://api.github.com/search/issues?q=repo%3Ajanus-idp%2Fbackstage-showcase+state%3Aopen+type%3Apr+created%3A<$PREVIOUS_DT&type=Issues"
 url2="https://api.github.com/search/issues?q=repo%3Ajanus-idp%2Fbackstage-plugins+state%3Aopen+type%3Apr+created%3A<$PREVIOUS_DT&type=Issues"
-url3="https://api.github.com/search/issues?q=repo%3Ajanus-idp%2Foperator+state%3Aopen+type%3Apr+created%3A<$PREVIOUS_DT&type=Issues"
 url4="https://api.github.com/search/issues?q=repo%3Ajanus-idp%2Fjanus-idp.github.io+state%3Aopen+type%3Apr+created%3A<$PREVIOUS_DT&type=Issues"
 url5="https://api.github.com/search/issues?q=repo%3Aredhat-developer%2Fred-hat-developers-documentation-rhdh+state%3Aopen+type%3Apr+created%3A<$PREVIOUS_DT&type=Issues"
 
@@ -19,9 +18,6 @@ github_data_a+="\n<https://github.com/search?q=repo%3Ajanus-idp%2Fbackstage-show
 
 github_data_b="\n<https://github.com/search?l=&q=repo%3Ajanus-idp%2Fbackstage-plugins+state%3Aopen+type%3Apr | Total open PRs>: $(curl -s 'https://api.github.com/search/issues?q=repo%3Ajanus-idp%2Fbackstage-plugins+state%3Aopen+type%3Apr' -H "Accept: application/json" | jq '.total_count // 0')"
 github_data_b+="\n<https://github.com/search?q=repo%3Ajanus-idp%2Fbackstage-plugins+state%3Aopen+type%3Apr+created%3A%3C$PREVIOUS_DT&type=Issues | PRs opened for more than a week>: $(curl -s $url2 -H "Accept: application/json" | jq '.total_count // 0')"
-
-github_data_c="\n<https://github.com/search?l=&q=repo%3Ajanus-idp%2Foperator+state%3Aopen+type%3Apr | Total open PRs>: $(curl -s 'https://api.github.com/search/issues?q=repo%3Ajanus-idp%2Foperator+state%3Aopen+type%3Apr' -H "Accept: application/json" | jq '.total_count // 0')"
-github_data_c+="\n<https://github.com/search?q=repo%3Ajanus-idp%2Foperator+state%3Aopen+type%3Apr+created%3A%3C$PREVIOUS_DT&type=Issues | PRs opened for more than a week>: $(curl -s $url3 -H "Accept: application/json" | jq '.total_count // 0')"
 
 github_data_d="\n<https://github.com/search?l=&q=repo%3Ajanus-idp%2Fjanus-idp.github.io+state%3Aopen+type%3Apr | Total open PRs>: $(curl -s 'https://api.github.com/search/issues?q=repo%3Ajanus-idp%2Fjanus-idp.github.io+state%3Aopen+type%3Apr' -H "Accept: application/json" | jq '.total_count // 0')"
 github_data_d+="\n<https://github.com/search?q=repo%3Ajanus-idp%2Fjanus-idp.github.io+state%3Aopen+type%3Apr+created%3A%3C$PREVIOUS_DT&type=Issues | PRs opened for more than a week>: $(curl -s $url4 -H "Accept: application/json" | jq '.total_count // 0')"
@@ -77,27 +73,6 @@ data='{
         {
           "type": "mrkdwn",
           "text": "'$github_data_b'"
-        }
-      ]
-    },
-    {
-      "type": "divider"
-    },
-    {
-      "type": "section",
-      "fields": [
-        {
-          "type": "mrkdwn",
-          "text": "*backstage-operator*"
-        }
-      ]
-    },
-    {
-      "type": "section",
-      "fields": [
-        {
-          "type": "mrkdwn",
-          "text": "'$github_data_c'"
         }
       ]
     },


### PR DESCRIPTION
This PR removes the operator repo from backstage status script and posts the status once every week at 4PM IST Monday.